### PR TITLE
Feature/write erase sector rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [IRNAS's naming guidelines](https://github.com/IRNAS
 
 ## [Unreleased]
 
+### Changed
+
+-   Rework how sector sizes are specified in DTS.
+
 ## [2.1.0] - 2022-07-07
 
 ### Changed
 
-- Remove unnecessary board overlays form tests.
-- Migrate code to run on NCS 2.0
+-   Remove unnecessary board overlays form tests.
+-   Migrate code to run on NCS 2.0
 
 ## [2.0.5] - 2022-05-03
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you already have a NCS setup you can follow these steps:
       repo-path: zephyr-spi-flash-en25-driver
       path: irnas/zephyr-spi-flash-en25-driver
       remote: irnas
-      revision: v2.1.0
+      revision: v3.0.0
     ```
 
 3. Then run `west update` in your freshly created bash/command prompt session.
@@ -43,21 +43,27 @@ If you already have a NCS setup you can follow these steps:
 &spi0 {
    // ...
 
-    en25: en25qh32b@0 {
+    en25qh32b: en25qh32b@0 {
         reg = <0>;
         label = "EN25QH32B";
         status = "okay";
         compatible = "irnas,en25";
 
-        jedec-id = [1c 70 16];
-        size = <33554432>;
-        sector-size = <4096>;
-        block-size = <4096>;
-        page-size = <256>;
-        spi-max-frequency = <104000000>;
+        jedec-id = [ 1c 70 16  ];  // EN25
+        size = <(4194304 * 8)>;
+
+        write-sector-size = <256>;
+        erase-full-block-size = <65536>;
+        erase-half-block-size = <32768>;
+        erase-sector-size = <4096>;
+
+        spi-max-frequency = <4000000>;
 
         enter-dpd-delay = <30>;
         exit-dpd-delay = <30>;
+
+        wp-gpios = <&gpio0 22 0>;
+        hold-gpios = <&gpio0 23 0>;
     };
 };
 

--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -28,7 +28,7 @@ config SPI_FLASH_EN25_INIT_PRIORITY
 
 config SPI_FLASH_EN25_READY_TIMEOUT
 	int "Max duration to wait for ready status of en25 in milliseconds"
-	default 10000
+	default 50000
 	help
 	  For some operations the driver must wait for en25 to become ready.
 	  This config specifies the maximum duration the driver will wait.

--- a/dts/bindings/irnas,en25.yaml
+++ b/dts/bindings/irnas,en25.yaml
@@ -18,20 +18,32 @@ properties:
     required: true
     description: Flash capacity in bits.
 
-  sector-size:
+  write-sector-size:
     type: int
     required: true
-    description: Flash sector size in bytes.
+    description: |
+      Write sector size (in bytes). This might be called "programmable page" or
+      something similar in the datasheet.
 
-  block-size:
+  erase-full-block-size:
     type: int
     required: true
-    description: Flash block size in bytes.
+    description: |
+      The size (in bytes) of a full block for erase purposes.
 
-  page-size:
+  erase-half-block-size:
     type: int
     required: true
-    description: Flash page size in bytes.
+    description: |
+      The size (in bytes) of a half block for erase purposes.
+
+  erase-sector-size:
+    type: int
+    required: true
+    description: |
+      The size (in bytes) of a sector for erase purposes. This size
+      should be the smallest erasable sector/block/page that the chip supports.
+      NOTE: This driver assumes a uniform sector architecture.
 
   use-udpd:
     type: boolean
@@ -67,7 +79,7 @@ properties:
     type: phandle-array
     required: false
     description: WPn pin
-    
+
   hold-gpios:
     type: phandle-array
     required: false


### PR DESCRIPTION
Rework of the DTS configuration based on a mismatch between the datasheet and the zephyr flash API.

The assumed version after the PR is merged is `3.0.0`, since the changes are breaking.

PR can be reviewed by going through the commit history.